### PR TITLE
Update tlsh2 to v1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,9 +498,9 @@ source = "git+https://github.com/dkrisman/tlsh-rs?branch=main#2079d86b6a35bb399a
 
 [[package]]
 name = "tlsh2"
-version = "0.4.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1ca7b6482798eaf06ef6a4a5e1211e370758888698cfff4a53142441ef5143"
+checksum = "96c92ccae5fece4be87f4fe90187d5bf20837e7a50f14c1f664b4a86c97ea3e0"
 
 [[package]]
 name = "tlsh_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = "1"
 divan = "0.1.21"
 
 fast-tlsh = { version = "0.1.8" }
-tlsh2 = { version = "0.4.0", features = ["diff", "fast"] }
+tlsh2 = { version = "1.0.0", features = ["diff", "fast"] }
 simbiota-tlsh = "1.1.1"
 tlsh_orig = { git = "https://github.com/dkrisman/tlsh-rs", branch = "main", package = "tlsh" }
 ffuzzy = { version = "0.3.16", features = ["unsafe", "unchecked", "unstable"] }

--- a/README.md
+++ b/README.md
@@ -15,32 +15,35 @@ For more information about TLSH goto: https://tlsh.org/
 
 Used system:
 ```bash
-Arch Linux 6.14.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 10 Apr 2025 18:43:59 +0000 x86_64 GNU/Linux
-AMD Ryzen 9 5950X 16-Core Processor
-128GB RAM 3600Mhz
+NixOS Linux 6.15.7 #1-NixOS SMP PREEMPT_DYNAMIC Thu Jul 17 16:44:05 UTC 2025 x86_64 GNU/Linux
+Intel Core Ultra 7 155H 22-Core Processor
+32GB RAM 7467Mhz
 ```
 
 
 
-Running benches/tlsh_construct_bench.rs (target/release/deps/tlsh_construct_bench-50750479aa4e76a9)
-Timer precision: 20 ns
+Running benches/tlsh_construct_bench.rs (target/release/deps/tlsh_construct_bench-c1c03f39143dd24a)
+Timer precision: 10 ns
 
 ```
 tlsh_construct_bench        fastest       │ slowest       │ median        │ mean          │ samples │ iters
-├─ construct_fast_tlsh      16.78 ms      │ 42.61 ms      │ 16.88 ms      │ 17.81 ms      │ 100     │ 100
-├─ construct_simbiota_tlsh  64.55 ms      │ 70.86 ms      │ 65.36 ms      │ 65.77 ms      │ 100     │ 100
-├─ construct_tlsh2          31.24 ms      │ 34.42 ms      │ 31.45 ms      │ 31.64 ms      │ 100     │ 100
-╰─ construct_tlsh_orig      55.82 ms      │ 61.18 ms      │ 56.18 ms      │ 56.37 ms      │ 100     │ 100
+├─ construct_fast_tlsh      16.2 ms       │ 16.71 ms      │ 16.29 ms      │ 16.3 ms       │ 100     │ 100
+├─ construct_ffuzzy         37.63 ms      │ 38.39 ms      │ 37.79 ms      │ 37.81 ms      │ 100     │ 100
+├─ construct_simbiota_tlsh  42.76 ms      │ 43.39 ms      │ 43.02 ms      │ 43.02 ms      │ 100     │ 100
+├─ construct_tlsh2          19.38 ms      │ 19.48 ms      │ 19.43 ms      │ 19.43 ms      │ 100     │ 100
+╰─ construct_tlsh_orig      49.12 ms      │ 49.39 ms      │ 49.25 ms      │ 49.25 ms      │ 100     │ 100
+
 ```
 
-Running benches/tlsh_diff_bench.rs (target/release/deps/tlsh_diff_bench-f393e696b6c3e0e7)
-Timer precision: 20 ns
+Running benches/tlsh_diff_bench.rs (target/release/deps/tlsh_diff_bench-ed6bf55555eeaf47)
+Timer precision: 10 ns
 
 ```
 tlsh_diff_bench        fastest       │ slowest       │ median        │ mean          │ samples │ iters
-├─ diff_fast_tlsh      4.492 ms      │ 5.29 ms       │ 4.58 ms       │ 4.591 ms      │ 100     │ 100
-├─ diff_simbiota_tlsh  13.88 ms      │ 14.72 ms      │ 14.01 ms      │ 14.03 ms      │ 100     │ 100
-├─ diff_tlsh2          17.52 ms      │ 20.72 ms      │ 17.93 ms      │ 18.06 ms      │ 100     │ 100
-╰─ diff_tlsh_orig      23.43 ms      │ 41.19 ms      │ 23.8 ms       │ 24.08 ms      │ 100     │ 100
+├─ diff_fast_tlsh      4.593 ms      │ 5.878 ms      │ 4.68 ms       │ 4.709 ms      │ 100     │ 100
+├─ diff_ffuzzy         53.64 ms      │ 55.04 ms      │ 53.77 ms      │ 53.79 ms      │ 100     │ 100
+├─ diff_simbiota_tlsh  203.5 ms      │ 204.7 ms      │ 203.6 ms      │ 203.7 ms      │ 100     │ 100
+├─ diff_tlsh2          15.43 ms      │ 16.65 ms      │ 15.52 ms      │ 15.56 ms      │ 100     │ 100
+╰─ diff_tlsh_orig      25.46 ms      │ 26.5 ms       │ 25.71 ms      │ 25.8 ms       │ 100     │ 100
 
 ```


### PR DESCRIPTION
The second patch illustrates the impact to results on my hardware, and is welcome to be replaced.